### PR TITLE
Create JuankoOS base with OpenAI modules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Rename this file to .env and set your OpenAI API key
+OPENAI_API_KEY=your_openai_api_key_here

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Hola, soy **@LGBTR543** 🌈 | Hi, I’m **@LGBTR543** 🌟  
+
+### 💡 **¿Qué me mueve? / What drives me?**  
+- Explorar lo desconocido con curiosidad y pasión 🌍.  
+- Colaborar en ideas que enciendan creatividad y propósito ✨.  
+- Construir puentes que conecten personas, proyectos y sueños.  
+
+---
+
+### 🚀 **En qué estoy enfocado ahora / What I’m focused on now:**  
+1. 🌱 **Aprendiendo:**  
+   - Desarrollo web moderno (¡de cero a wow!) 💻.  
+   - Comunicación efectiva en equipo y colaboración 🤝.  
+2. 🛠️ **Construyendo:**  
+   - Proyectos que combinen simplicidad e innovación.  
+   - Espacios inclusivos para crecer y brillar juntos 🌈.  
+
+---
+
+### 🤝 **¿Cómo colaborar conmigo? / How to collaborate with me?**  
+- Trae tus ideas: las transformamos en acción.  
+- Busco proyectos creativos donde podamos aprender juntos.  
+- Lo importante es la *vibra*: conexión genuina + crecimiento.  
+
+---
+
+### 📫 **Cómo contactarme / How to reach me:**  
+- **Correo / Email:** [info@juankotara.com](mailto:info@juankotara.com)  
+- **Instagram:** [@juanko.tara](https://www.instagram.com/juanko.tara/)    
+
+---
+
+### 🎉 **Un fun fact para conocernos más / A fun fact about me:**  
+- Me encanta aprender en el caos: donde todo parece incierto, ahí es donde surgen las mejores ideas 🚀.  
+
+## JuankoOS
+
+Para iniciar el servidor local:
+1. Copia `.env.example` a `.env` y agrega tu clave de OpenAI.
+2. Instala dependencias: `npm install`.
+3. Ejecuta `node src/index.js` y visita `http://localhost:3000`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "lgbtr543",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>JuankoOS</title>
+  <style>
+    body {
+      background-color: #0d0d0d;
+      color: #d4af37; /* gold */
+      font-family: Arial, sans-serif;
+      text-align: center;
+      padding: 2rem;
+    }
+    h1 {
+      color: #9b59b6; /* purple */
+    }
+    input, button {
+      padding: 0.5rem;
+      margin: 0.5rem;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      * {
+        transition: none !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <h1>JuankoOS™</h1>
+  <p>Genera letras, eslóganes y rituales místicos.</p>
+  <form id="genForm">
+    <select id="type" aria-label="Tipo de generación">
+      <option value="lyrics">Letra</option>
+      <option value="slogan">Slogan</option>
+      <option value="ritual">Ritual</option>
+    </select>
+    <input id="prompt" type="text" placeholder="Tema" required />
+    <button type="submit">Generar</button>
+  </form>
+  <pre id="result"></pre>
+  <script>
+    document.getElementById('genForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const type = document.getElementById('type').value;
+      const prompt = document.getElementById('prompt').value;
+      const res = await fetch('/api/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type, prompt })
+      });
+      const data = await res.json();
+      document.getElementById('result').textContent = data.result || data.error;
+    });
+  </script>
+</body>
+</html>

--- a/src/components/lyrics.js
+++ b/src/components/lyrics.js
@@ -1,0 +1,13 @@
+const { OpenAI } = require('openai');
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+async function generateLyrics(prompt = '') {
+  const completion = await openai.chat.completions.create({
+    messages: [{ role: 'user', content: `Write poetic lyrics about ${prompt}` }],
+    model: 'gpt-3.5-turbo'
+  });
+  return completion.choices[0].message.content.trim();
+}
+
+module.exports = { generateLyrics };

--- a/src/components/rituals.js
+++ b/src/components/rituals.js
@@ -1,0 +1,13 @@
+const { OpenAI } = require('openai');
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+async function generateRitual(prompt = '') {
+  const completion = await openai.chat.completions.create({
+    messages: [{ role: 'user', content: `Describe a mystical ritual for ${prompt}` }],
+    model: 'gpt-3.5-turbo'
+  });
+  return completion.choices[0].message.content.trim();
+}
+
+module.exports = { generateRitual };

--- a/src/components/slogans.js
+++ b/src/components/slogans.js
@@ -1,0 +1,13 @@
+const { OpenAI } = require('openai');
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+async function generateSlogan(prompt = '') {
+  const completion = await openai.chat.completions.create({
+    messages: [{ role: 'user', content: `Create a short, catchy slogan for ${prompt}` }],
+    model: 'gpt-3.5-turbo'
+  });
+  return completion.choices[0].message.content.trim();
+}
+
+module.exports = { generateSlogan };

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const { generateLyrics } = require('./components/lyrics');
+const { generateSlogan } = require('./components/slogans');
+const { generateRitual } = require('./components/rituals');
+require('dotenv').config();
+
+const app = express();
+app.use(express.json());
+app.use(express.static('public'));
+
+app.post('/api/generate', async (req, res) => {
+  const { type, prompt } = req.body || {};
+  try {
+    let result;
+    switch (type) {
+      case 'lyrics':
+        result = await generateLyrics(prompt);
+        break;
+      case 'slogan':
+        result = await generateSlogan(prompt);
+        break;
+      case 'ritual':
+        result = await generateRitual(prompt);
+        break;
+      default:
+        return res.status(400).json({ error: 'Invalid type' });
+    }
+    res.json({ result });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`JuankoOS listening on port ${port}`);
+});

--- a/src/store/README.md
+++ b/src/store/README.md
@@ -1,0 +1,3 @@
+# Store Module
+
+Este directorio está pensado para integrar futuras funcionalidades de monetización, como la venta de productos digitales o membresías dentro de JuankoOS. Aquí se podrían incluir APIs de pago e integraciones con plataformas externas.


### PR DESCRIPTION
## Summary
- initialize Node project and add environment file example
- add Express server to serve JuankoOS front-end
- add generation modules for lyrics, slogans and rituals using OpenAI
- include responsive HTML with mystical design colors
- document how to run the server

## Testing
- `node --check src/index.js`
- `node src/index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68735225ef44832f819205d4d6b6661e