### PR TITLE
Add initial JuankoOS skeleton

### DIFF
--- a/Update README.md
+++ b/Update README.md
@@ -32,3 +32,14 @@
 
 ### 🎉 **Un fun fact para conocernos más / A fun fact about me:**  
 - Me encanta aprender en el caos: donde todo parece incierto, ahí es donde surgen las mejores ideas 🚀.  
+
+---
+
+## JuankoOS\u2122
+Una plataforma creativa y espiritual que combina generación de contenido con experiencias digitales.
+
+- Uso de OpenAI para crear líricas, esloganes y rituales.
+- Interfaz web inspirada en tonos púrpura, negro y oro.
+- Diseñada para escalar en Google Kubernetes Engine.
+- Monetización mediante productos digitales y membresías.
+

--- a/juankoos/__init__.py
+++ b/juankoos/__init__.py
@@ -1,0 +1,9 @@
+"""JuankoOS package initialization."""
+
+from .content import generate_lyrics, generate_slogan, generate_ritual
+
+__all__ = [
+    "generate_lyrics",
+    "generate_slogan",
+    "generate_ritual",
+]

--- a/juankoos/app.py
+++ b/juankoos/app.py
@@ -1,0 +1,31 @@
+"""Minimal Flask app to interact with JuankoOS."""
+
+from flask import Flask, render_template, request, jsonify
+from .content import generate_lyrics, generate_slogan, generate_ritual
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/generate", methods=["POST"])
+def generate():
+    data = request.json or {}
+    action = data.get("action")
+    text = data.get("text", "")
+    if action == "lyrics":
+        result = generate_lyrics(text)
+    elif action == "slogan":
+        result = generate_slogan(text)
+    elif action == "ritual":
+        result = generate_ritual(text)
+    else:
+        return jsonify({"error": "Invalid action"}), 400
+    return jsonify({"result": result})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/juankoos/content.py
+++ b/juankoos/content.py
@@ -1,0 +1,47 @@
+"""Content generation utilities for JuankoOS."""
+
+import os
+from typing import Optional
+
+import openai
+
+OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-3.5-turbo")
+
+
+def _call_openai(prompt: str, *, model: str = OPENAI_MODEL) -> str:
+    """Call OpenAI's chat completion API with a basic prompt."""
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("OPENAI_API_KEY environment variable not set")
+
+    openai.api_key = api_key
+    response = openai.ChatCompletion.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.8,
+    )
+    return response.choices[0].message["content"].strip()
+
+
+def generate_lyrics(topic: str) -> str:
+    """Generate mystical lyrics about a topic."""
+    prompt = (
+        f"Compose short mystical song lyrics about '{topic}'. "
+        "Use poetic language."
+    )
+    return _call_openai(prompt)
+
+
+def generate_slogan(theme: str) -> str:
+    """Generate a catchy slogan."""
+    prompt = f"Create an inspiring slogan with a {theme} theme."
+    return _call_openai(prompt)
+
+
+def generate_ritual(intention: str) -> str:
+    """Generate a simple spiritual ritual."""
+    prompt = (
+        f"Describe a short spiritual ritual to manifest '{intention}'. "
+        "Keep it uplifting and symbolic."
+    )
+    return _call_openai(prompt)

--- a/juankoos/static/style.css
+++ b/juankoos/static/style.css
@@ -1,0 +1,26 @@
+body {
+    background-color: #000;
+    color: #f0e6ff;
+    font-family: Arial, sans-serif;
+    text-align: center;
+    margin: 0;
+    padding: 0;
+}
+
+header {
+    background: linear-gradient(90deg, #462255, #8a2be2, #ffd700);
+    padding: 1em;
+    color: white;
+}
+
+button {
+    background-color: #ffd700;
+    color: #000;
+    border: none;
+    padding: 0.5em 1em;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #8a2be2;
+}

--- a/juankoos/templates/index.html
+++ b/juankoos/templates/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>JuankoOS</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<header>
+  <h1>JuankoOS</h1>
+  <p>Creative & Spiritual Assistant</p>
+</header>
+
+<section id="actions">
+  <input type="text" id="inputText" placeholder="Enter your topic here">
+  <button onclick="send('lyrics')">Generate Lyrics</button>
+  <button onclick="send('slogan')">Generate Slogan</button>
+  <button onclick="send('ritual')">Generate Ritual</button>
+</section>
+
+<pre id="output"></pre>
+
+<script>
+async function send(action) {
+  const text = document.getElementById('inputText').value;
+  const res = await fetch('/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action, text })
+  });
+  const data = await res.json();
+  document.getElementById('output').textContent = data.result || data.error;
+}
+</script>
+</body>
+</html>

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Setup environment variables for JuankoOS deployment on GKE
+
+export PROJECT_ID="<YOUR PROJECT ID>"
+export REGION="<YOUR REGION>"
+export ZONE="<YOUR ZONE>"
+export CLUSTER_NAME="nim-demo"
+export NODE_POOL_MACHINE_TYPE="g2-standard-16"
+export CLUSTER_MACHINE_TYPE="e2-standard-4"
+export GPU_TYPE="nvidia-l4"
+export GPU_COUNT=1
+
+echo "Environment variables configured."


### PR DESCRIPTION
## Summary
- add `juankoos` package with OpenAI-powered content generation utilities
- add Flask web app with mystical themed interface
- add GKE environment setup script
- expand personal README with JuankoOS project description

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68797f19b798832f84d63e1efa2ea931