### PR TITLE
Add JuankoOS FastAPI scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.env
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,34 +1,39 @@
-# Hola, soy **@LGBTR543** 🌈 | Hi, I’m **@LGBTR543** 🌟  
+# JuankoOS™ · plataforma creativa y espiritual
 
-### 💡 **¿Qué me mueve? / What drives me?**  
-- Explorar lo desconocido con curiosidad y pasión 🌍.  
-- Colaborar en ideas que enciendan creatividad y propósito ✨.  
-- Construir puentes que conecten personas, proyectos y sueños.  
+Base mínima para JuankoOS™, inspirada en Juanko Tara y optimizada para crear experiencias simbólicas, contenido y monetización consciente.
 
----
+## Características
+- 🎤 Generadores determinísticos para lyrics, slogans y rituales (`juankoos/content.py`).
+- 🔮 Identidad de marca centralizada (paleta, símbolos, tono) en `juankoos/config.py`.
+- 🤖 Bridge listo para la API de OpenAI con prompts alineados a la voz de Juanko (`juankoos/openai_bridge.py`).
+- 🕸️ Interfaz web FastAPI + Jinja con estilos místicos responsivos (`app.py`, `templates/index.html`, `static/styles.css`).
+- 💰 Endpoints para membresías y tienda digital que ayudan a preparar landing pages.
 
-### 🚀 **En qué estoy enfocado ahora / What I’m focused on now:**  
-1. 🌱 **Aprendiendo:**  
-   - Desarrollo web moderno (¡de cero a wow!) 💻.  
-   - Comunicación efectiva en equipo y colaboración 🤝.  
-2. 🛠️ **Construyendo:**  
-   - Proyectos que combinen simplicidad e innovación.  
-   - Espacios inclusivos para crecer y brillar juntos 🌈.  
+## Cómo correr
+1. Crea y activa un entorno virtual.
+2. Instala dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. (Opcional) Exporta tu clave:
+   ```bash
+   export OPENAI_API_KEY="tu_clave"
+   ```
+4. Levanta el servidor:
+   ```bash
+   uvicorn app:app --reload --port 8000
+   ```
+5. Abre http://localhost:8000 para ver la experiencia mística.
 
----
+## Endpoints útiles
+- `POST /api/lyrics` → `{ "theme": "", "mood": "", "language": "es|en" }`
+- `POST /api/slogan` → `{ "seed": "" }`
+- `POST /api/ritual` → `{ "intention": "", "duration": 11 }`
+- `POST /api/membership` → `{ "name": "", "price": "", "benefits": "benef1;benef2" }`
+- `POST /api/shop` → `{ "title": "", "format": "PDF", "value": "curso express" }`
+- `POST /api/openai` → `{ "task": "describe un lanzamiento", ... }` (requiere `OPENAI_API_KEY`)
 
-### 🤝 **¿Cómo colaborar conmigo? / How to collaborate with me?**  
-- Trae tus ideas: las transformamos en acción.  
-- Busco proyectos creativos donde podamos aprender juntos.  
-- Lo importante es la *vibra*: conexión genuina + crecimiento.  
-
----
-
-### 📫 **Cómo contactarme / How to reach me:**
-- **Correo / Email:** [info@juankotara.com](mailto:info@juankotara.com)
-- **Instagram:** [@juanko.tara](https://www.instagram.com/juanko.tara/)
-
----
-
-### 🎉 **Un fun fact para conocernos más / A fun fact about me:**
-- Me encanta aprender en el caos: donde todo parece incierto, ahí es donde surgen las mejores ideas 🚀.
+## Notas de diseño
+- Paleta dorado/negro/púrpura con acentos glow para transmitir misterio.
+- Accesibilidad: esquema oscuro declarado y respeto a `prefers-reduced-motion`.
+- Texto bilingüe para amplificar alcance y resonancia.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+from typing import Dict
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from juankoos import (
+    BRAND_PALETTE,
+    BRAND_SYMBOLS,
+    JUANKO_TONE,
+    JuankoOpenAI,
+    craft_membership_tier,
+    create_shop_item,
+    design_ritual,
+    generate_lyrics,
+    generate_slogan,
+)
+
+app = FastAPI(title="JuankoOS™", version="0.1.0", description="Creative spiritual OS")
+
+base_path = Path(__file__).parent
+app.mount("/static", StaticFiles(directory=base_path / "static"), name="static")
+templates = Jinja2Templates(directory=str(base_path / "templates"))
+
+
+def build_context() -> Dict[str, str]:
+    return {
+        "palette": BRAND_PALETTE,
+        "symbols": BRAND_SYMBOLS,
+        "tone": JUANKO_TONE,
+    }
+
+
+@app.get("/", response_class=HTMLResponse)
+async def home(request: Request) -> HTMLResponse:
+    context = {"request": request, **build_context()}
+    return templates.TemplateResponse("index.html", context)
+
+
+@app.post("/api/lyrics")
+async def lyrics(payload: Dict[str, str]):
+    theme = payload.get("theme")
+    mood = payload.get("mood")
+    if not theme or not mood:
+        raise HTTPException(status_code=422, detail="theme and mood are required")
+    return {"result": generate_lyrics(theme, mood, payload.get("language", "es"))}
+
+
+@app.post("/api/slogan")
+async def slogan(payload: Dict[str, str]):
+    seed = payload.get("seed")
+    if not seed:
+        raise HTTPException(status_code=422, detail="seed is required")
+    return {"result": generate_slogan(seed)}
+
+
+@app.post("/api/ritual")
+async def ritual(payload: Dict[str, str]):
+    intention = payload.get("intention")
+    if not intention:
+        raise HTTPException(status_code=422, detail="intention is required")
+    duration = int(payload.get("duration", 11))
+    return {"result": design_ritual(intention, duration)}
+
+
+@app.post("/api/membership")
+async def membership(payload: Dict[str, str]):
+    name = payload.get("name")
+    price = payload.get("price")
+    benefits_raw = payload.get("benefits", "")
+    if not name or not price:
+        raise HTTPException(status_code=422, detail="name and price are required")
+    benefits = [b.strip() for b in benefits_raw.split(";") if b.strip()]
+    return {"result": craft_membership_tier(name, benefits, price)}
+
+
+@app.post("/api/shop")
+async def shop(payload: Dict[str, str]):
+    title = payload.get("title")
+    format_hint = payload.get("format")
+    value = payload.get("value")
+    if not title or not format_hint or not value:
+        raise HTTPException(status_code=422, detail="title, format, and value are required")
+    return {"result": create_shop_item(title, format_hint, value)}
+
+
+@app.post("/api/openai")
+async def openai_generate(payload: Dict[str, str]):
+    task = payload.get("task")
+    if not task:
+        raise HTTPException(status_code=422, detail="task is required")
+    generator = JuankoOpenAI(model=payload.get("model", "gpt-4o-mini"))
+    result = generator.generate(task, payload)
+    return {"result": result}

--- a/juankoos/__init__.py
+++ b/juankoos/__init__.py
@@ -1,0 +1,17 @@
+"""JuankoOS™ creative core package."""
+
+from .config import BRAND_PALETTE, BRAND_SYMBOLS, JUANKO_TONE
+from .content import generate_lyrics, generate_slogan, design_ritual, craft_membership_tier, create_shop_item
+from .openai_bridge import JuankoOpenAI
+
+__all__ = [
+    "BRAND_PALETTE",
+    "BRAND_SYMBOLS",
+    "JUANKO_TONE",
+    "generate_lyrics",
+    "generate_slogan",
+    "design_ritual",
+    "craft_membership_tier",
+    "create_shop_item",
+    "JuankoOpenAI",
+]

--- a/juankoos/config.py
+++ b/juankoos/config.py
@@ -1,0 +1,29 @@
+"""Shared configuration and brand language for JuankoOS™."""
+
+BRAND_PALETTE = {
+    "primary": "#C59D5F",  # gold
+    "secondary": "#301934",  # deep purple
+    "accent": "#0F0F10",  # black
+    "glow": "#6E4B7A",
+}
+
+BRAND_SYMBOLS = {
+    "sigil": "✺",
+    "mantra": "Respira, crea, trasciende.",
+    "emoji": "🌗",
+}
+
+JUANKO_TONE = {
+    "voice": "poético, protector y directo",
+    "persona": "Juanko Tara, alquimista urbano y mentor creativo",
+    "values": [
+        "inclusión radical",
+        "arte como ritual",
+        "prosperidad consciente",
+    ],
+}
+
+CONTENT_PREAMBLE = (
+    "Habla como Juanko Tara: místico, cálido, bilingüe cuando conviene, "
+    "dando imágenes doradas y violetas."
+)

--- a/juankoos/content.py
+++ b/juankoos/content.py
@@ -1,0 +1,60 @@
+"""Deterministic content generators to keep JuankoOS™ creative."""
+
+from datetime import datetime
+from typing import Dict, List
+
+from .config import BRAND_SYMBOLS, CONTENT_PREAMBLE, JUANKO_TONE
+
+
+def generate_lyrics(theme: str, mood: str, language: str = "es") -> str:
+    """Create short, bilingual-friendly lyrics with a mystical tone."""
+    moon_phase = BRAND_SYMBOLS["emoji"]
+    stamp = datetime.utcnow().strftime("%Y-%m-%d")
+    bridge = " / " if language == "es" else " – "
+    opening = f"{CONTENT_PREAMBLE} {moon_phase}"
+    verse = f"{theme.title()} en {mood.lower()}" if language == "es" else f"{theme.title()} in {mood.lower()}"
+    outro = (
+        "Somos brasa y luz, danzando con las sombras." if language == "es" else "We are ember and light, dancing with the shadows."
+    )
+    return f"{opening}\n[{stamp}] {verse}{bridge}{outro}"
+
+
+def generate_slogan(seed: str) -> str:
+    """Propose a brand-ready slogan for campaigns and product drops."""
+    return (
+        f"{BRAND_SYMBOLS['sigil']} {seed.strip().title()} → oro vivo, comunidad despierta."
+    )
+
+
+def design_ritual(intention: str, duration_minutes: int = 11) -> Dict[str, str]:
+    """Blueprint for a symbolic ritual session."""
+    return {
+        "intention": intention,
+        "duration": f"{duration_minutes} minutos de presencia dorada",
+        "steps": (
+            "1) Respira en 4-4-4-4. 2) Escribe tu visión en dos idiomas. "
+            "3) Afirma en voz alta. 4) Cierra con agua y luz violeta."
+        ),
+        "closing": BRAND_SYMBOLS["mantra"],
+    }
+
+
+def craft_membership_tier(name: str, benefits: List[str], price: str) -> Dict[str, str]:
+    """Describe a membership tier for monetization."""
+    formatted_benefits = "; ".join(benefits)
+    return {
+        "name": name.title(),
+        "price": price,
+        "benefits": formatted_benefits,
+        "energy": "Círculo íntimo para artistas conscientes",
+    }
+
+
+def create_shop_item(title: str, format_hint: str, value: str) -> Dict[str, str]:
+    """Describe a digital product slot for the store."""
+    return {
+        "title": title.title(),
+        "format": format_hint,
+        "value": value,
+        "call_to_action": f"Descarga y desbloquea {BRAND_SYMBOLS['sigil']} en tu proceso creativo.",
+    }

--- a/juankoos/openai_bridge.py
+++ b/juankoos/openai_bridge.py
@@ -1,0 +1,41 @@
+"""Lightweight wrapper to send JuankoOS™ prompts to OpenAI."""
+
+import os
+from typing import Dict
+
+from .config import CONTENT_PREAMBLE, JUANKO_TONE
+
+
+class JuankoOpenAI:
+    """Tiny helper around the OpenAI client."""
+
+    def __init__(self, model: str = "gpt-4o-mini") -> None:
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError("OPENAI_API_KEY is required to use JuankoOpenAI")
+
+        from openai import OpenAI  # type: ignore
+
+        self.client = OpenAI(api_key=api_key)
+        self.model = model
+
+    def craft_prompt(self, task: str, payload: Dict[str, str]) -> str:
+        values = ", ".join(JUANKO_TONE["values"])
+        core = (
+            f"{CONTENT_PREAMBLE}\nTono: {JUANKO_TONE['voice']}. "
+            f"Persona: {JUANKO_TONE['persona']}. Valores: {values}."
+        )
+        details = "\n".join([f"- {k}: {v}" for k, v in payload.items()])
+        return f"{core}\nTarea: {task}.\nContexto:\n{details}\nResponde conciso y en dos idiomas cuando aporte claridad."
+
+    def complete(self, prompt: str) -> str:
+        response = self.client.responses.create(
+            model=self.model,
+            input=[{"role": "user", "content": prompt}],
+            temperature=0.8,
+        )
+        return response.output_text
+
+    def generate(self, task: str, payload: Dict[str, str]) -> str:
+        prompt = self.craft_prompt(task, payload)
+        return self.complete(prompt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.0
+Jinja2==3.1.4
+openai==1.35.14

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,110 @@
+:root {
+  --gold: #c59d5f;
+  --purple: #301934;
+  --black: #0f0f10;
+  --glow: #6e4b7a;
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Space Grotesk", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(110, 75, 122, 0.2), transparent),
+    radial-gradient(circle at 80% 0%, rgba(197, 157, 95, 0.25), transparent),
+    var(--black);
+  color: #f5f1ff;
+  min-height: 100vh;
+}
+
+header.hero {
+  position: relative;
+  text-align: center;
+  padding: 4rem 1.5rem 3rem;
+  overflow: hidden;
+}
+
+header.hero .halo {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle, rgba(197, 157, 95, 0.25), rgba(48, 25, 52, 0.8), transparent 70%);
+  filter: blur(50px);
+  z-index: 0;
+}
+
+header.hero .sigil {
+  position: relative;
+  z-index: 1;
+  font-size: 2rem;
+  color: var(--gold);
+  margin: 0;
+}
+
+header.hero h1 {
+  position: relative;
+  z-index: 1;
+  margin: 0.4rem 0;
+  font-size: 2.8rem;
+  letter-spacing: 0.1em;
+}
+
+header.hero .subtitle,
+header.hero .mantra {
+  position: relative;
+  z-index: 1;
+  margin: 0.2rem 0;
+  color: #e9ddff;
+}
+
+main.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.2rem;
+  padding: 0 1.5rem 3rem;
+}
+
+.card {
+  background: rgba(48, 25, 52, 0.55);
+  border: 1px solid rgba(197, 157, 95, 0.3);
+  border-radius: 16px;
+  padding: 1.2rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(8px);
+}
+
+.card h2 {
+  margin-top: 0;
+  color: var(--gold);
+}
+
+.card ul {
+  padding-left: 1.2rem;
+  color: #d9c8ff;
+}
+
+.card .hint {
+  margin-top: 0.7rem;
+  color: #cfc7e3;
+  font-size: 0.9rem;
+}
+
+.card.tone {
+  background: linear-gradient(145deg, rgba(197, 157, 95, 0.12), rgba(48, 25, 52, 0.8));
+}
+
+footer {
+  text-align: center;
+  padding: 1.5rem;
+  color: #b9adc5;
+  font-size: 0.95rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0ms !important;
+    transition-duration: 0ms !important;
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JuankoOS™ | Ritual creativo</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="halo"></div>
+      <p class="sigil">{{ symbols.sigil }}</p>
+      <h1>JuankoOS™</h1>
+      <p class="subtitle">Plataforma creativa + espiritual basada en Juanko Tara</p>
+      <p class="mantra">{{ symbols.mantra }}</p>
+    </header>
+
+    <main class="grid">
+      <section class="card">
+        <h2>Generador de contenido</h2>
+        <p>Lyrics, slogans y rituales listos para campañas o sesiones en vivo.</p>
+        <ul>
+          <li><strong>Lírica:</strong> POST /api/lyrics</li>
+          <li><strong>Slogan:</strong> POST /api/slogan</li>
+          <li><strong>Ritual:</strong> POST /api/ritual</li>
+        </ul>
+        <p class="hint">Envía JSON con <code>theme</code>, <code>mood</code>, <code>seed</code> o <code>intention</code>.</p>
+      </section>
+
+      <section class="card">
+        <h2>Monetización</h2>
+        <p>Define membresías y productos digitales en segundos.</p>
+        <ul>
+          <li><strong>Membership:</strong> POST /api/membership</li>
+          <li><strong>Tienda:</strong> POST /api/shop</li>
+        </ul>
+        <p class="hint">Recibe un blueprint listo para landing pages o newsletters.</p>
+      </section>
+
+      <section class="card">
+        <h2>OpenAI ready</h2>
+        <p>Conecta la API de OpenAI con el tono oficial de Juanko Tara.</p>
+        <ul>
+          <li><strong>Endpoint:</strong> POST /api/openai</li>
+          <li><strong>Env var:</strong> <code>OPENAI_API_KEY</code></li>
+        </ul>
+        <p class="hint">Payload incluye <code>task</code> y los campos que quieras enriquecer.</p>
+      </section>
+
+      <section class="card tone">
+        <h2>Identidad y voz</h2>
+        <p><strong>Voz:</strong> {{ tone.voice }}</p>
+        <p><strong>Persona:</strong> {{ tone.persona }}</p>
+        <p><strong>Valores:</strong> {{ ", ".join(tone.values) }}</p>
+      </section>
+    </main>
+
+    <footer>
+      <p>Oro • Negro • Púrpura · Respira, crea, trasciende.</p>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold JuankoOS core package with brand config, deterministic content generators, and OpenAI bridge
- add FastAPI app with endpoints for content, monetization blueprints, and OpenAI-powered outputs
- introduce mystical responsive landing page and supporting styles plus project docs and dependencies

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68a7cd3301d4832f86d2d7885f93581e)